### PR TITLE
entryScript: Add udev to entry script

### DIFF
--- a/app/systemd/entry.sh
+++ b/app/systemd/entry.sh
@@ -1,14 +1,61 @@
 #!/bin/bash
 
- set -m
+set -m
 
- # Send SIGTERM to child processes of PID 1.
+if hostname "$HOSTNAME" &> /dev/null; then
+	PRIVILEGED=true
+else
+	PRIVILEGED=false
+fi
+
+# Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
 	kill "$pid"
 }
 
- function init_systemd()
+function start_udev()
+{
+	if [ "$UDEV" == "on" ]; then
+		if [ "$INITSYSTEM" != "on" ]; then
+			if command -v udevd &>/dev/null; then
+				unshare --net udevd --daemon &> /dev/null
+			else
+				unshare --net /lib/systemd/systemd-udevd --daemon &> /dev/null
+			fi
+			udevadm trigger &> /dev/null
+		fi
+	else
+		if [ "$INITSYSTEM" == "on" ]; then
+			systemctl mask systemd-udevd
+		fi
+	fi
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug
+}
+
+function init_systemd()
 {
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
@@ -17,26 +64,26 @@ function signal_handler()
 	done > /etc/docker.env
 	echo 'source /etc/docker.env' >> ~/.bashrc
 
- 	printf '#!/bin/bash\n exec ' > /etc/balenaApp.sh
-	printf '%q ' "$@" >> /etc/balenaApp.sh
-	chmod +x /etc/balenaApp.sh
+	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
+	printf '%q ' "$@" >> /etc/resinApp.sh
+	chmod +x /etc/resinApp.sh
 
- 	mkdir -p /etc/systemd/system/balena.service.d
-	cat <<-EOF > /etc/systemd/system/balena.service.d/override.conf
+	mkdir -p /etc/systemd/system/resin.service.d
+	cat <<-EOF > /etc/systemd/system/resin.service.d/override.conf
 		[Service]
 		WorkingDirectory=$(pwd)
 	EOF
 
- 	sleep infinity &
+	sleep infinity &
 	exec env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket /sbin/init quiet systemd.show_status=0
 }
 
- function init_non_systemd()
+function init_non_systemd()
 {
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
- 	# echo error message, when executable file doesn't exist.
+	# echo error message, when executable file doesn't exist.
 	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		"$CMD" "$@" &
@@ -50,15 +97,21 @@ function signal_handler()
 	fi
 }
 
- INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
+INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
 
- case "$INITSYSTEM" in
+case "$INITSYSTEM" in
 	'1' | 'true')
 		INITSYSTEM='on'
 	;;
 esac
 
- if [ "$INITSYSTEM" = "on" ]; then
+if $PRIVILEGED; then
+	# Only run this in privileged container
+	mount_dev
+	start_udev
+fi
+
+if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"
 else
 	init_non_systemd "$@"


### PR DESCRIPTION
Based on the example entry script in base-images repo https://github.com/balena-io-library/base-images/blob/master/examples/INITSYSTEM/systemd/systemd.v230/entry.sh

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>